### PR TITLE
Fix reward calculation on the dashboard

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -786,7 +786,7 @@ function Dash_calc(){
 	
 	for(var i = 0; i < 6; i++){
 		if($D['block'][i]){
-			rew = rew + parseFloat($D['block'][i]['reward']);
+			rew = rew + parseFloat($D['block'][i]['reward'].replace($L['dec'], '.'));
 			j++;
 		}
 	}


### PR DESCRIPTION
Block rewards are stored in locale-specific format, so they were being truncated on locales that don't use a decimal point.

This bug became noticeable after the block reward dropped below 2 XMR.